### PR TITLE
Navbar hides initial content when jumping to in-page anchor

### DIFF
--- a/src/sphinxjp/themes/basicstrap/templates/basicstrap/layout.html
+++ b/src/sphinxjp/themes/basicstrap/templates/basicstrap/layout.html
@@ -124,6 +124,24 @@
        }
     });
   });
+  $(window).load(function () {
+    /*
+
+     * Scroll the window to avoid the topnav bar
+     * https://github.com/twitter/bootstrap/issues/1768
+     */
+    if ($(".navbar.navbar-fixed-top").length > 0) {
+      // var navHeight = $(".navbar").height(),
+      var navHeight = 40,
+        shiftWindow = function() { scrollBy(0, -navHeight - 10); };
+
+      if (location.hash) {
+        setTimeout(shiftWindow, 1);
+      }
+
+      window.addEventListener("hashchange", shiftWindow);
+    }
+  });
 </script>
 {%- endmacro %}
 


### PR DESCRIPTION
Hi,

First, thanks for the awesome theme! It's really beautiful and efficient.

I've realised that there is the same issue than the one described in https://github.com/twbs/bootstrap/issues/1768.

I don't know if it's intended or not. Anyways, I've copied their solution and added it to your theme.
Yet, I don't get it why I can't retrieve the height from the navbar. Thus in my solution I directly use the raw value in the code.

```
// var navHeight = $(".navbar").height(),
 var navHeight = 40,
```

Let me know what you think.

Best regards,
Pierre
